### PR TITLE
Correct capitalization of filename in #include directive

### DIFF
--- a/src/DL_PAC_NK76.h
+++ b/src/DL_PAC_NK76.h
@@ -1,4 +1,4 @@
-#include <arduino.h>
+#include <Arduino.h>
 
 #ifndef DL_PAC_NK76_h
 #define DL_PAC_NK76_h


### PR DESCRIPTION
Incorrect capitalization of Arduino.h causes compilation to fail on filename case-sensitive operating systems like Linux.